### PR TITLE
fix: build of kubelet with Ceph on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,9 @@ RUN clean-install \
   util-linux
 
 RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
-RUN echo deb https://download.ceph.com/debian-octopus/ bullseye main | tee /etc/apt/sources.list.d/ceph.list
+# TODO: Ceph packages are broken for arm64, so we used packages available in Debian itself for now
+ARG TARGETARCH
+RUN if [ ${TARGETARCH} == "amd64" ]; then echo deb https://download.ceph.com/debian-pacific/ bullseye main | tee /etc/apt/sources.list.d/ceph.list; fi
 RUN apt-get clean \
   && clean-install ceph-common
 


### PR DESCRIPTION
Old release 'octopus' is EoL:
https://docs.ceph.com/en/quincy/releases/index.html

New releases pacific/quincy have a problem with arm64 packages: they are
not built for arm64, which breaks the install. Use `ceph-common` from
Debian for `ceph-common` on arm64 as a workaround for now.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>