### PR TITLE
chore: update kubernetes release buckets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:latest as builder-amd64
 ARG TARGETARCH
 ARG KUBELET_VER
 ARG KUBELET_SHA512_AMD64
-ARG KUBELET_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBELET_VER}/bin/linux/${TARGETARCH}/kubelet
+ARG KUBELET_URL=https://dl.k8s.io/release/${KUBELET_VER}/bin/linux/${TARGETARCH}/kubelet
 
 RUN wget -q -O /kubelet ${KUBELET_URL} \
   && sha512sum /kubelet \
@@ -18,7 +18,7 @@ FROM alpine:latest as builder-arm64
 ARG TARGETARCH
 ARG KUBELET_VER
 ARG KUBELET_SHA512_ARM64
-ARG KUBELET_URL=https://storage.googleapis.com/kubernetes-release/release/${KUBELET_VER}/bin/linux/${TARGETARCH}/kubelet
+ARG KUBELET_URL=https://dl.k8s.io/release/${KUBELET_VER}/bin/linux/${TARGETARCH}/kubelet
 
 RUN wget -q -O /kubelet ${KUBELET_URL} \
   && sha512sum /kubelet \

--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,5 @@ container:
 update-sha: update-sha-amd64 update-sha-arm64 ## Updates the kubelet sha512 checksums in the Makefile.
 
 update-sha-%:
-	sha512=`curl -sL https://storage.googleapis.com/kubernetes-release/release/$(KUBELET_VER)/bin/linux/${*}/kubelet.sha512`; \
+	sha512=`curl -sL https://dl.k8s.io/release/$(KUBELET_VER)/bin/linux/${*}/kubelet.sha512`; \
 		sed -i "s/KUBELET_SHA512_$(shell echo '$*' | tr '[:lower:]' '[:upper:]') := .*/KUBELET_SHA512_$(shell echo '$*' | tr '[:lower:]' '[:upper:]') := $${sha512}/" Makefile


### PR DESCRIPTION
This PR changes the url used in the Makefile from a legacy URL to point to the new community owned download host.