### PR TITLE
Add iscsiadm wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ FROM registry.k8s.io/build-image/debian-iptables:bullseye-v1.5.7 as container
 
 RUN clean-install \
   --allow-change-held-packages \
+  procps \
   bash \
   ca-certificates \
   libcap2 \
@@ -58,6 +59,9 @@ RUN apt-get clean \
   && clean-install ceph-common
 
 COPY --from=builder /kubelet /usr/local/bin/kubelet
+
+# Add wrapper for iscsiadm
+COPY files/iscsiadm /usr/local/sbin/iscsiadm
 
 LABEL org.opencontainers.image.source https://github.com/siderolabs/kubelet
 

--- a/files/iscsiadm
+++ b/files/iscsiadm
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+iscsid_pid=$(pgrep iscsid)
+
+if [ -z "${iscsid_pid}"]; then
+    >&2 echo ERROR: Cannot find iscsid PID
+    exit 1
+fi
+
+exec nsenter --target=${iscsid_pid} --mount --net -- /usr/local/sbin/iscsiadm "$@"


### PR DESCRIPTION
In order to create an `iscsi` PV, `kubelet` needs access to `iscsiadm`. Similar trick is described in Talos documentation [here](https://www.talos.dev/v1.4/kubernetes-guides/configuration/replicated-local-storage-with-openebs-jiva/#patching-the-jiva-installation).