### PR TITLE
fix: dockerfile argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ FROM builder-${TARGETARCH} AS builder
 
 FROM ${BASE_IMAGE} AS container-fat
 
+ARG SLIM_PACKAGES
 RUN clean-install \
   --allow-change-held-packages \
   ${SLIM_PACKAGES} \
@@ -63,6 +64,7 @@ ENTRYPOINT ["/usr/local/bin/kubelet"]
 
 FROM ${BASE_IMAGE} AS container-slim
 
+ARG SLIM_PACKAGES
 RUN clean-install \
   --allow-change-held-packages \
   ${SLIM_PACKAGES}


### PR DESCRIPTION
The `ARG` as missing, so `${SLIM_PACKAGES}` resolved to empty :(

Fixes https://github.com/siderolabs/talos/issues/9190