### PR TITLE
fix: make iscsiadm script work with any POSIX shell

### DIFF
--- a/files/iscsiadm
+++ b/files/iscsiadm
@@ -2,7 +2,7 @@
 
 iscsid_pid=$(pgrep iscsid)
 
-if [ -z "${iscsid_pid}"]; then
+if [ -z "${iscsid_pid}" ]; then
     >&2 echo ERROR: Cannot find iscsid PID
     exit 1
 fi


### PR DESCRIPTION
[This commit](https://github.com/siderolabs/kubelet/commit/6c43bd116674237704f006c8377bac967a8a54f4) changed the shell used to run this script from `bash` to `sh`. This PR fixes the script to work with `sh`.