### PR TITLE
fix: make kubelet executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN cosign verify-blob "/kubelet" \
   --certificate-identity krel-staging@k8s-releng-prod.iam.gserviceaccount.com \
   --certificate-oidc-issuer https://accounts.google.com
 
+RUN chmod +x /kubelet
+
 ########################
 
 FROM ${BASE_IMAGE} AS base-updated


### PR DESCRIPTION
While refactoring for cosign, I accidentally dropped the command to chmod +x kubelet.